### PR TITLE
fix a diff problem between hhvm and php5.6 while using redis mget(receive an empty array) 

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -1094,6 +1094,9 @@ class Redis {
    * "*2\r\n$3\r\nGET\r\n$7\r\nsomekey\r\n"
    */
   protected function processArrayCommand($cmd, array $args) {
+    if(empty($args)){
+      return false;
+    }
     if ($this->mode == self::PIPELINE) {
       $this->commands[] = [ 'cmd' => $cmd, 'args' => $args ];
       return true;
@@ -1496,7 +1499,9 @@ class Redis {
 
     if ($format == '...') {
       $args = $this->translateVarArgs($args, $func['vararg']);
-      $this->processArrayCommand($func['cmd'], $args);
+      if(!$this->processArrayCommand($func['cmd'], $args)){
+        return false;
+      }
       if (empty($func['handler'])) {
         return null;
       }
@@ -1544,7 +1549,9 @@ class Redis {
       $args[1] = $args[2];
       $args[2] = $tmp;
     }
-    $this->processArrayCommand($func['cmd'], $args);
+    if(!$this->processArrayCommand($func['cmd'], $args)){
+      return false;
+    }
     if (empty($func['handler'])) {
       return null;
     }

--- a/hphp/test/zend/good/ext/redis/redis_mget.php
+++ b/hphp/test/zend/good/ext/redis/redis_mget.php
@@ -1,0 +1,5 @@
+<?php
+  $r = new Redis();
+  $conn = $r->connect('10.58.41.51', 9003, 10 );
+  $res = $r->mget(array());
+  var_dump($res);

--- a/hphp/test/zend/good/ext/redis/redis_mget.php.expectf
+++ b/hphp/test/zend/good/ext/redis/redis_mget.php.expectf
@@ -1,0 +1,1 @@
+bool(false)


### PR DESCRIPTION
while using redis mget with an empty array, php5.6 will return false right now, but hhvm will wait for redis server response timeout, and then return NULL.
this patch will fix the diff problem.
